### PR TITLE
make sure no media path is prepended if there is no MEDIA_URL setting set in django

### DIFF
--- a/django_thumbor/__init__.py
+++ b/django_thumbor/__init__.py
@@ -19,7 +19,7 @@ def _remove_schema(url):
 
 
 def _prepend_media_url(url):
-    if url.startswith(settings.MEDIA_URL):
+    if settings.MEDIA_URL and url.startswith(settings.MEDIA_URL):
         url = _remove_prefix(url, settings.MEDIA_URL)
         url.lstrip('/')
         return '%s/%s' % (conf.THUMBOR_MEDIA_URL, url)

--- a/testproject/tests/test_generate_url.py
+++ b/testproject/tests/test_generate_url.py
@@ -93,6 +93,10 @@ class TestURLFixing(TestCase):
         self.assertURLEquals('/media/uploads/image.jpg',
                              'localhost:8000/media/uploads/image.jpg')
 
+    @override_settings(MEDIA_URL="")
+    def test_should_not_prepend_media_url_if_none_is_set(self):
+        self.assertURLEquals('http://www.domain.com/media/uploads/image.jpg', 'www.domain.com/media/uploads/image.jpg')
+
     def test_should_remove_the_scheme_from_external_images(self):
         self.assertURLEquals('http://some.domain.com/path/image.jpg',
                              'some.domain.com/path/image.jpg')


### PR DESCRIPTION
I had MEDIA_URL="" in my settings, and couldn't get rid of the THUMBOR_MEDIA_URL prefix that was prepended. 

I finally figured out that this is because any URL begins with the empty string "", so the check in the code is insufficient.