### PR TITLE
make sure URLs with special characters don't fail by quoting them before passing to thumbor

### DIFF
--- a/django_thumbor/__init__.py
+++ b/django_thumbor/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from urllib2 import quote
 from libthumbor import CryptoURL
 from django_thumbor import conf
 from django.conf import settings
@@ -27,6 +28,7 @@ def _prepend_media_url(url):
 
 
 def generate_url(image_url, **kwargs):
+    image_url = quote(image_url)
     image_url = _prepend_media_url(image_url)
     image_url = _remove_schema(image_url)
 


### PR DESCRIPTION
Image URLs with special characters like '+' or '?' in them fail badly with a HTTP status 400 when passed to thumbor. The fix is to quote URLs before passing them to thumbor, as suggested here https://github.com/thumbor/thumbor/issues/666 

Not sure how to best test this in the current test suite... I tried with a simple test, but things like the 'http://' removal fails and some others tests fail (although I think the actual behavior is correct).