### PR TITLE
THUMBOR_STATIC_ENABLED getting value from Django settings

### DIFF
--- a/django_thumbor/conf.py
+++ b/django_thumbor/conf.py
@@ -11,7 +11,7 @@ THUMBOR_SERVER = getattr(settings, 'THUMBOR_SERVER',
 THUMBOR_MEDIA_URL = getattr(settings, 'THUMBOR_MEDIA_URL',
                             'http://localhost:8000/media').rstrip('/')
 
-THUMBOR_STATIC_ENABLED = getattr(settings, 'THUMBOR_STATIC_ENABLED', True)
+THUMBOR_STATIC_ENABLED = getattr(settings, 'THUMBOR_STATIC_ENABLED', False)
 
 THUMBOR_STATIC_URL = getattr(settings, 'THUMBOR_STATIC_URL',
                             'http://localhost:8000/static').rstrip('/')

--- a/django_thumbor/conf.py
+++ b/django_thumbor/conf.py
@@ -11,7 +11,7 @@ THUMBOR_SERVER = getattr(settings, 'THUMBOR_SERVER',
 THUMBOR_MEDIA_URL = getattr(settings, 'THUMBOR_MEDIA_URL',
                             'http://localhost:8000/media').rstrip('/')
 
-THUMBOR_STATIC_ENABLED = False
+THUMBOR_STATIC_ENABLED = getattr(settings, 'THUMBOR_STATIC_ENABLED', True)
 
 THUMBOR_STATIC_URL = getattr(settings, 'THUMBOR_STATIC_URL',
                             'http://localhost:8000/static').rstrip('/')


### PR DESCRIPTION
In the current version the THUMBOR_STATIC_ENABLED is fixed as False, don't respecting the Django Configuration, making impossible to enable this feature, I did a change to inherit the configuration's value.
