### PR TITLE
Don't assume it's always safe to strip `http://` prefix from URLs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,11 @@ Here are the default settings that you can override:
     # configurations without repeating yourself.
     THUMBOR_ALIASES = {}
 
+    # Strip `http://` prefix for prettier URLs. Thumbor's HTTP loader will
+    # add these back in, but this will break HTTP loading via the
+    # `TC_AWS_ENABLE_HTTP_LOADER=True` setting for `thumbor-community/aws`.
+    THUMBOR_STRIP_HTTP = True
+
 
 Contributing
 ------------

--- a/django_thumbor/__init__.py
+++ b/django_thumbor/__init__.py
@@ -17,7 +17,9 @@ def _remove_prefix(url, prefix):
 
 
 def _remove_schema(url):
-    return _remove_prefix(url, 'http://')
+    if conf.THUMBOR_STRIP_HTTP:
+        return _remove_prefix(url, 'http://')
+    return url
 
 
 def _prepend_media_url(url):

--- a/django_thumbor/conf.py
+++ b/django_thumbor/conf.py
@@ -27,3 +27,8 @@ THUMBOR_ARGUMENTS = getattr(settings, 'THUMBOR_ARGUMENTS', {})
 # the url generating function instead of the arguments. Allows re-use
 # of thumbnail types across the app.
 THUMBOR_ALIASES = getattr(settings, 'THUMBOR_ALIASES', {})
+
+# Strip `http://` prefix for prettier URLs. Thumbor's HTTP loader will
+# add these back in, but this will break HTTP loading via the
+# `TC_AWS_ENABLE_HTTP_LOADER=True` setting for `thumbor-community/aws`.
+THUMBOR_STRIP_HTTP = getattr(settings, 'THUMBOR_STRIP_HTTP', True)


### PR DESCRIPTION
While the default HTTP loader will re-append it, the AWS loader will
instead try to load from the default S3 bucket and media root, instead
of falling back to the HTTP loader.

Set `THUMBOR_STRIP_HTTP = False` to disable.