### PR TITLE
Improve image url handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,19 @@ Both ``thumbor_url`` templatetag and the ``generate_url`` helper uses the same
 arguments as `libthumbor <https://github.com/heynemann/libthumbor>`_, you can
 check the `wiki <https://github.com/heynemann/libthumbor/wiki>`_ for more info.
 
+You can pass an absolute URL, protocol relative URL (which Thumbor will attempt
+to load over HTTP), a path relative URL (beginning with `/`, which will be
+prefixed with the value of `THUMBOR_ROOT_URL`), or a name to be used with the
+default storage class.
+
 On templates:
 
 .. code-block:: html
+
+    {% load thumbor_tags %}
+    <img src="{% thumbor_url 'image.jpg' width=300 %}" width="300" />
+
+    or
 
     {% load thumbor_tags %}
     <img src="{% thumbor_url '/media/image.jpg' width=300 %}" width="300" />
@@ -42,13 +52,45 @@ On templates:
     or
 
     {% load thumbor_tags %}
+    <img src="{% thumbor_url '//example.com/media/image.jpg' width=300 %}" width="300" />
+
+    or
+
+    {% load thumbor_tags %}
+    <img src="{% thumbor_url 'http://example.com/media/image.jpg' width=300 %}" width="300" />
+
+    or
+
+    {% load thumbor_tags %}
     <img src="{% thumbor_url model.image_field width=300 %}" width="300" />
 
-If you need the result in a template variable, use `assign_thumbor_url` instead.
+If you need a thumbnail for a static file:
+
+.. code-block:: html
+
+    {% load thumbor_tags %}
+    <img src="{% static_thumbor_url 'image.jpg' width=300 %}" width="300" />
+
+    is equivalent to
+
+    {% load staticfiles thumbor_tags %}
+    <img src="{% static "image.jpg" as image_url %}{% thumbor_url image_url width=300 %}" width="300" />
+
+If you need the result in a template variable, use `assign_thumbor_url` or
+`assign_static_thumbor_url`, instead.
+
+.. code-block:: html
 
     {% load thumbor_tags %}
     {% assign_thumbor_url '/media/image.jpg' width=300 as thumb_url %}
     <img src="{{ thumb_url }}" width="300" />
+
+    or
+
+    {% load thumbor_tags %}
+    {% assign_static_thumbor_url 'image.jpg' width=300 as thumb_url %}
+    <img src="{{ thumb_url }}" width="300" />
+
 
 **Filters**
 
@@ -152,17 +194,10 @@ Here are the default settings that you can override:
     # The host serving the thumbor resized images
     THUMBOR_SERVER = 'http://localhost:8888'
 
-    # The prefix for the host serving the original images
-    # This must be a resolvable address to allow thumbor to reach the images
-    THUMBOR_MEDIA_URL = 'http://localhost:8000/media'
-
-    # If you want the static to be handled by django thumbor
-    # default as False, set True to handle it if you host your statics
-    THUMBOR_STATIC_ENABLED = False
-
-    # The prefix for the host serving the original static images
-    # this must be a resolvable address to allow thumbor to reach the images
-    THUMBOR_STATIC_URL = 'http://localhost:8000/static'
+    # The prefix for the host serving images with relative URLs.
+    # This must be a resolvable address to allow thumbor to reach the images.
+    THUMBOR_ROOT_URL = getattr(
+        settings, 'THUMBOR_ROOT_URL', 'http://localhost:8000').rstrip('/')
 
     # The same security key used in the thumbor service to
     # match the URL construction

--- a/django_thumbor/__init__.py
+++ b/django_thumbor/__init__.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 import logging
 import re
+import urllib
 logger = logging.getLogger(__name__)
 
 
@@ -36,10 +37,10 @@ def _handle_relative(url):
     # to be used with the default storage class. We check this first, because
     # the storage class might return a relative URL that needs further
     # processing.
-    if not re.match(r'^(/|https?://)', url):
+    if not re.match(r'^(/|https?(:|%s)//)' % urllib.quote(':'), url):
         url = default_storage.url(url)
     # Return absolute URLs as-is.
-    if re.match(r'^https?://', url):
+    if re.match(r'^https?(:|%s)//' % urllib.quote(':'), url):
         return url
     # We don't have access to a request object, so we have to assume that
     # protocol relative URLs will be available to Thumbor over HTTP.

--- a/django_thumbor/conf.py
+++ b/django_thumbor/conf.py
@@ -6,15 +6,10 @@ from django.conf import settings
 THUMBOR_SERVER = getattr(settings, 'THUMBOR_SERVER',
                          'http://localhost:8888').rstrip('/')
 
-# The prefix for the host serving the original images
-# This must be a resolvable address to allow thumbor to reach the images
-THUMBOR_MEDIA_URL = getattr(settings, 'THUMBOR_MEDIA_URL',
-                            'http://localhost:8000/media').rstrip('/')
-
-THUMBOR_STATIC_ENABLED = False
-
-THUMBOR_STATIC_URL = getattr(settings, 'THUMBOR_STATIC_URL',
-                            'http://localhost:8000/static').rstrip('/')
+# The prefix for the host serving images with relative URLs.
+# This must be a resolvable address to allow thumbor to reach the images.
+THUMBOR_ROOT_URL = getattr(
+    settings, 'THUMBOR_ROOT_URL', 'http://localhost:8000').rstrip('/')
 
 # The same security key used in the thumbor service to
 # match the URL construction

--- a/django_thumbor/templatetags/thumbor_tags.py
+++ b/django_thumbor/templatetags/thumbor_tags.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django import template
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django_thumbor import generate_url
 
 register = template.Library()
@@ -16,6 +17,7 @@ except:
 has_assignment_tag = hasattr(register, 'assignment_tag')
 assignment_tag = has_assignment_tag and register.assignment_tag() or register.simple_tag
 
+
 def _parse_filters(filters):
     # Forces an empty filter to the end of the list
     filters += ':'
@@ -23,6 +25,7 @@ def _parse_filters(filters):
     filters = [f + ')' for f in filters.split('):')]
     # Ignores the empty filter at the end
     return filters[:-1]
+
 
 @register.simple_tag
 def thumbor_url(image_url, **kwargs):
@@ -32,6 +35,17 @@ def thumbor_url(image_url, **kwargs):
 
     return generate_url(image_url=image_url, **kwargs)
 
+
+@register.simple_tag
+def static_thumbor_url(image_url, **kwargs):
+    """
+    A convenience tag to avoid having to do
+    `{% static "FOO" as foo %}{% thumbor_url foo ... %}`.
+    """
+    image_url = staticfiles_storage.url(image_url)
+    return thumbor_url(image_url, **kwargs)
+
+
 @assignment_tag
 def assign_thumbor_url(image_url, **kwargs):
     """
@@ -40,3 +54,13 @@ def assign_thumbor_url(image_url, **kwargs):
     {% assign_thumbor_url image_url="/test/pic.jpg" width=300 as thumbnail %}
     """
     return thumbor_url(image_url=image_url, **kwargs)
+
+
+@assignment_tag
+def assign_static_thumbor_url(image_url, **kwargs):
+    """
+    A convenience tag to avoid having to do
+    `{% static "FOO" as foo %}{% assign_thumbor_url foo ... as foo %}`.
+    """
+    image_url = staticfiles_storage.url(image_url)
+    return assign_thumbor_url(image_url, **kwargs)


### PR DESCRIPTION
* Replace `THUMBOR_MEDIA_URL` and `THUMBOR_STATIC_URL` settings with a
  single `THUMBOR_ROOT_URL` setting.

  These two settings exist to ensure we pass an absolute URL to Thumbor,
  so that it can download original images. If we just assume that any
  relative URL will be served by Django, media or static, we only need
  the one `THUMBOR_ROOT_URL` setting.

* Remove the pointless `THUMBOR_STATIC_ENABLED` setting. It was hard
  coded to `False`, and if someone wants to generate a thumbnail for a
  static file, they should just pass in an absolute or relative URL for
  it.

* Assume that protocol relative URLs beginning with "//" can be loaded
  by Thumbor over HTTP.

* Assume that relative paths not beginning with a `/` are storage object
  names, and generate a URL with the default storage class.

* Add `{% static_thumbor_url %}` and `{% assign_static_thumbor_url %}`
  tags as a convenience, so we can pass static file storage object names
  and avoid `{% static "FOO" as foo %}{% thumbor_url foo ... %}`.

* Don't assume that a "http" prefix is enough to indicate an absolute
  URL. This would break on storage object names beginning with "http".
  Check for "http://" and "https://".

* Do URL handling *after* generating URLs with default storage class,
  because storage classes can return relative URLs.

* Use two line breaks between module level functions in modules with new
  code, for consistency and PEP8.