### PR TITLE
Bump version: 0.5.7 → 0.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,6 @@
 commit = True
 tag = True
 tag_name = {new_version}
-current_version = 0.5.7
+current_version = 0.6.0
 
 [bumpversion:file:setup.py]
-

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-thumbor',
-    version='0.5.7',
+    version='0.6.0',
     description=(
         'A django application to resize images using the thumbor service'),
     long_description=open('README.rst').read(),


### PR DESCRIPTION
Mostly just changes to CI to ensure support for most recent Django versions.